### PR TITLE
feat: customizable logo and 'Hey! Carlton' branding

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -7,7 +7,7 @@
 		<link rel="icon" type="image/svg+xml" href="/static/favicon.svg" />
 		<link rel="shortcut icon" href="/static/favicon.ico" />
 		<link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png" />
-		<meta name="apple-mobile-web-app-title" content="Open WebUI" />
+		<meta name="apple-mobile-web-app-title" content="Hey! Carlton" />
 
 		<link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
 		<meta
@@ -16,11 +16,11 @@
 		/>
 		<meta name="theme-color" content="#171717" />
 		<meta name="robots" content="noindex,nofollow" />
-		<meta name="description" content="Open WebUI" />
+		<meta name="description" content="Hey! Carlton" />
 		<link
 			rel="search"
 			type="application/opensearchdescription+xml"
-			title="Open WebUI"
+			title="Hey! Carlton"
 			href="/opensearch.xml"
 		/>
 		<script src="/static/loader.js" defer></script>
@@ -79,10 +79,14 @@
 				const isDarkMode = document.documentElement.classList.contains('dark');
 
 				const logo = document.createElement('img');
-				logo.id = 'logo';
+                                const storedLogo = localStorage.getItem('customLogo');
+                                logo.id = 'logo';
 				logo.style =
 					'position: absolute; width: auto; height: 6rem; top: 44%; left: 50%; transform: translateX(-50%); display:block;';
-				logo.src = isDarkMode ? '/static/splash-dark.png' : '/static/splash.png';
+				logo.src = storedLogo || (isDarkMode ? '/static/splash-dark.png' : '/static/splash.png');
+                                if (storedLogo) {
+                                        document.querySelectorAll("link[rel='icon'], link[rel='apple-touch-icon'], link[rel='shortcut icon']").forEach((el) => (el.href = storedLogo));
+                                }
 
 				document.addEventListener('DOMContentLoaded', function () {
 					const splash = document.getElementById('splash-screen');
@@ -91,11 +95,15 @@
 					}
 
 					if (splash) splash.prepend(logo);
+                                        if (storedLogo) {
+                                                const logoHer = document.getElementById('logo-her');
+                                                if (logoHer) logoHer.src = storedLogo;
+                                        }
 				});
 			})();
 		</script>
 
-		<title>Open WebUI</title>
+		<title>Hey! Carlton</title>
 
 		%sveltekit.head%
 	</head>

--- a/src/lib/components/OnBoarding.svelte
+++ b/src/lib/components/OnBoarding.svelte
@@ -1,106 +1,137 @@
 <script>
-	import { getContext, onMount } from 'svelte';
-	const i18n = getContext('i18n');
+        import { getContext } from 'svelte';
+        const i18n = getContext('i18n');
 
-	import { WEBUI_BASE_URL } from '$lib/constants';
+        import { WEBUI_BASE_URL } from '$lib/constants';
+        import { customLogo } from '$lib/stores';
 
-	import Marquee from './common/Marquee.svelte';
-	import SlideShow from './common/SlideShow.svelte';
-	import ArrowRightCircle from './icons/ArrowRightCircle.svelte';
+        import Marquee from './common/Marquee.svelte';
+        import SlideShow from './common/SlideShow.svelte';
+        import ArrowRightCircle from './icons/ArrowRightCircle.svelte';
 
-	export let show = true;
-	export let getStartedHandler = () => {};
+        export let show = true;
+        export let getStartedHandler = () => {};
 
-	function setLogoImage() {
-		const logo = document.getElementById('logo');
+        let fileInput;
+        let customLogoValue = null;
+        customLogo.subscribe((v) => (customLogoValue = v));
 
-		if (logo) {
-			const isDarkMode = document.documentElement.classList.contains('dark');
+        function setLogoImage() {
+                const logo = document.getElementById('logo');
 
-			if (isDarkMode) {
-				const darkImage = new Image();
-				darkImage.src = `${WEBUI_BASE_URL}/static/favicon-dark.png`;
+                if (logo) {
+                        if (customLogoValue) {
+                                logo.src = customLogoValue;
+                                logo.style.filter = '';
+                                return;
+                        }
+                        const isDarkMode = document.documentElement.classList.contains('dark');
 
-				darkImage.onload = () => {
-					logo.src = `${WEBUI_BASE_URL}/static/favicon-dark.png`;
-					logo.style.filter = ''; // Ensure no inversion is applied if splash-dark.png exists
-				};
+                        if (isDarkMode) {
+                                const darkImage = new Image();
+                                darkImage.src = `${WEBUI_BASE_URL}/static/favicon-dark.png`;
 
-				darkImage.onerror = () => {
-					logo.style.filter = 'invert(1)'; // Invert image if splash-dark.png is missing
-				};
-			}
-		}
-	}
+                                darkImage.onload = () => {
+                                        logo.src = `${WEBUI_BASE_URL}/static/favicon-dark.png`;
+                                        logo.style.filter = '';
+                                };
 
-	$: if (show) {
-		setLogoImage();
-	}
+                                darkImage.onerror = () => {
+                                        logo.style.filter = 'invert(1)';
+                                };
+                        }
+                }
+        }
+
+        $: if (show) {
+                setLogoImage();
+        }
+
+        function handleLogoUpload(event) {
+                const target = event.target;
+                const file = target.files && target.files[0];
+                if (file) {
+                        const reader = new FileReader();
+                        reader.onload = (e) => {
+                                const result = e.target?.result;
+                                customLogo.set(result);
+                                localStorage.setItem('customLogo', result);
+                                setLogoImage();
+                                getStartedHandler();
+                        };
+                        reader.readAsDataURL(file);
+                } else {
+                        getStartedHandler();
+                }
+        }
+
+        function triggerLogoSelect() {
+                if (fileInput) fileInput.click();
+        }
 </script>
 
 {#if show}
-	<div class="w-full h-screen max-h-[100dvh] text-white relative">
-		<div class="fixed m-10 z-50">
-			<div class="flex space-x-2">
-				<div class=" self-center">
-					<img
-						id="logo"
-						crossorigin="anonymous"
-						src="{WEBUI_BASE_URL}/static/favicon.png"
-						class=" w-6 rounded-full"
-						alt="logo"
-					/>
-				</div>
-			</div>
-		</div>
+        <div class="w-full h-screen max-h[100dvh] text-white relative">
+                <input type="file" accept="image/png" class="hidden" bind:this={fileInput} on:change={handleLogoUpload} />
+                <div class="fixed m-10 z-50">
+                        <div class="flex space-x-2">
+                                <div class=" self-center">
+                                        <img
+                                                id="logo"
+                                                crossorigin="anonymous"
+                                                src={$customLogo || `${WEBUI_BASE_URL}/static/favicon.png`}
+                                                class=" w-6 rounded-full"
+                                                alt="logo"
+                                        />
+                                </div>
+                        </div>
+                </div>
 
-		<SlideShow duration={5000} />
+                <SlideShow duration={5000} />
 
-		<div
-			class="w-full h-full absolute top-0 left-0 bg-linear-to-t from-20% from-black to-transparent"
-		></div>
+                <div
+                        class="w-full h-full absolute top-0 left-0 bg-linear-to-t from-20% from-black to-transparent"
+                ></div>
 
-		<div class="w-full h-full absolute top-0 left-0 backdrop-blur-xs bg-black/50"></div>
+                <div class="w-full h-full absolute top-0 left-0 backdrop-blur-xs bg-black/50"></div>
 
-		<div class="relative bg-transparent w-full h-screen max-h-[100dvh] flex z-10">
-			<div class="flex flex-col justify-end w-full items-center pb-10 text-center">
-				<div class="text-5xl lg:text-7xl font-secondary">
-					<Marquee
-						duration={5000}
-						words={[
-							$i18n.t('Explore the cosmos'),
-							$i18n.t('Unlock mysteries'),
-							$i18n.t('Chart new frontiers'),
-							$i18n.t('Dive into knowledge'),
-							$i18n.t('Discover wonders'),
-							$i18n.t('Ignite curiosity'),
-							$i18n.t('Forge new paths'),
-							$i18n.t('Unravel secrets'),
-							$i18n.t('Pioneer insights'),
-							$i18n.t('Embark on adventures')
-						]}
-					/>
+                <div class="relative bg-transparent w-full h-screen max-h[100dvh] flex z-10">
+                        <div class="flex flex-col justify-end w-full items-center pb-10 text-center">
+                                <div class="text-5xl lg:text-7xl font-secondary">
+                                        <Marquee
+                                                duration={5000}
+                                                words={[
+                                                        $i18n.t('Explore the cosmos'),
+                                                        $i18n.t('Unlock mysteries'),
+                                                        $i18n.t('Chart new frontiers'),
+                                                        $i18n.t('Dive into knowledge'),
+                                                        $i18n.t('Discover wonders'),
+                                                        $i18n.t('Ignite curiosity'),
+                                                        $i18n.t('Forge new paths'),
+                                                        $i18n.t('Unravel secrets'),
+                                                        $i18n.t('Pioneer insights'),
+                                                        $i18n.t('Embark on adventures')
+                                                ]}
+                                        />
 
-					<div class="mt-0.5">{$i18n.t(`wherever you are`)}</div>
-				</div>
+                                        <div class="mt-0.5">{$i18n.t(`wherever you are`)}</div>
+                                </div>
 
-				<div class="flex justify-center mt-8">
-					<div class="flex flex-col justify-center items-center">
-						<button
-							aria-labelledby="get-started"
-							class="relative z-20 flex p-1 rounded-full bg-white/5 hover:bg-white/10 transition font-medium text-sm"
-							on:click={() => {
-								getStartedHandler();
-							}}
-						>
-							<ArrowRightCircle className="size-6" />
-						</button>
-						<div id="get-started" class="mt-1.5 font-primary text-base font-medium">
-							{$i18n.t(`Get started`)}
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
+                                <div class="flex justify-center mt-8">
+                                        <div class="flex flex-col justify-center items-center">
+                                                <button
+                                                        aria-labelledby="get-started"
+                                                        class="relative z-20 flex p-1 rounded-full bg-white/5 hover:bg-white/10 transition font-medium text-sm"
+                                                        on:click={triggerLogoSelect}
+                                                >
+                                                        <ArrowRightCircle className="size-6" />
+                                                </button>
+                                                <div id="get-started" class="mt-1.5 font-primary text-base font-medium">
+                                                        {$i18n.t(`Get started`)}
+                                                </div>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        </div>
 {/if}

--- a/src/lib/components/app/AppSidebar.svelte
+++ b/src/lib/components/app/AppSidebar.svelte
@@ -2,8 +2,14 @@
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import Plus from '$lib/components/icons/Plus.svelte';
 	import { WEBUI_BASE_URL } from '$lib/constants';
+        import { customLogo } from '$lib/stores';
 
-	let selected = '';
+        let selected = '';
+        let logoLarge: string;
+        let logoSmall: string;
+
+        $: logoLarge = $customLogo || `${WEBUI_BASE_URL}/static/splash.png`;
+        $: logoSmall = $customLogo || `${WEBUI_BASE_URL}/static/favicon.png`;
 </script>
 
 <div class="min-w-[4.5rem] bg-gray-50 dark:bg-gray-950 flex gap-2.5 flex-col pt-8">
@@ -26,7 +32,7 @@
 				}}
 			>
 				<img
-					src="{WEBUI_BASE_URL}/static/splash.png"
+					src="{logoLarge}"
 					class="size-11 dark:invert p-0.5"
 					alt="logo"
 					draggable="false"
@@ -50,7 +56,7 @@
 			}}
 		>
 			<img
-				src="{WEBUI_BASE_URL}/static/favicon.png"
+				src="{logoSmall}"
 				class="size-10 {selected === '' ? 'rounded-2xl' : 'rounded-full'}"
 				alt="logo"
 				draggable="false"

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,7 +1,7 @@
 import { browser, dev } from '$app/environment';
 // import { version } from '../../package.json';
 
-export const APP_NAME = 'Open WebUI';
+export const APP_NAME = 'Hey! Carlton';
 
 export const WEBUI_HOSTNAME = browser ? (dev ? `${location.hostname}:8080` : ``) : '';
 export const WEBUI_BASE_URL = browser ? (dev ? `http://${WEBUI_HOSTNAME}` : ``) : ``;

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -3,6 +3,7 @@ import resourcesToBackend from 'i18next-resources-to-backend';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import type { i18n as i18nType } from 'i18next';
 import { writable } from 'svelte/store';
+import { APP_NAME } from '$lib/constants';
 
 const createI18nStore = (i18n: i18nType) => {
 	const i18nWritable = writable(i18n);
@@ -45,27 +46,28 @@ export const initI18n = (defaultLocale?: string | undefined) => {
 
 	const loadResource = (language: string, namespace: string) =>
 		import(`./locales/${language}/${namespace}.json`);
-
-	i18next
-		.use(resourcesToBackend(loadResource))
-		.use(LanguageDetector)
-		.init({
-			debug: false,
-			detection: {
-				order: detectionOrder,
-				caches: ['localStorage'],
-				lookupQuerystring: 'lang',
-				lookupLocalStorage: 'locale'
-			},
-			fallbackLng: {
-				default: fallbackDefaultLocale
-			},
-			ns: 'translation',
-			returnEmptyString: false,
-			interpolation: {
-				escapeValue: false // not needed for svelte as it escapes by default
-			}
-		});
+        i18next
+                .use({ type: 'postProcessor', name: 'brand', process: (value) => value.replace(/Open WebUI/g, APP_NAME) })
+                .use(resourcesToBackend(loadResource))
+                .use(LanguageDetector)
+                .init({
+                        debug: false,
+                        detection: {
+                                order: detectionOrder,
+                                caches: ['localStorage'],
+                                lookupQuerystring: 'lang',
+                                lookupLocalStorage: 'locale'
+                        },
+                        fallbackLng: {
+                                default: fallbackDefaultLocale
+                        },
+                        ns: 'translation',
+                        returnEmptyString: false,
+                        interpolation: {
+                                escapeValue: false // not needed for svelte as it escapes by default
+                        },
+                        postProcess: ['brand']
+                });
 
 	const lang = i18next?.language || defaultLocale || 'en-US';
 	document.documentElement.setAttribute('lang', lang);

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -8,6 +8,7 @@ import emojiShortCodes from '$lib/emoji-shortcodes.json';
 
 // Backend
 export const WEBUI_NAME = writable(APP_NAME);
+export const customLogo: Writable<string | null> = writable(null);
 export const config: Writable<Config | undefined> = writable(undefined);
 export const user: Writable<SessionUser | undefined> = writable(undefined);
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -59,6 +59,12 @@
 
 	setContext('i18n', i18n);
 
+customLogo.subscribe((value) => {
+        if (value) {
+                document.querySelectorAll("link[rel='icon'], link[rel='apple-touch-icon'], link[rel='shortcut icon']").forEach((el) => el.setAttribute('href', value));
+        }
+});
+
 	const bc = new BroadcastChannel('active-tab-channel');
 
 	let loaded = false;
@@ -468,6 +474,11 @@
 	};
 
 	onMount(async () => {
+                const storedLogo = localStorage.getItem('customLogo');
+                if (storedLogo) {
+                        customLogo.set(storedLogo);
+                        document.querySelectorAll("link[rel='icon'], link[rel='apple-touch-icon'], link[rel='shortcut icon']").forEach((el) => el.setAttribute('href', storedLogo));
+                }
 		if (typeof window !== 'undefined' && window.applyTheme) {
 			window.applyTheme();
 		}

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -210,7 +210,7 @@
 									<img
 										id="logo"
 										crossorigin="anonymous"
-										src="{WEBUI_BASE_URL}/static/favicon.png"
+										src={$customLogo || `${WEBUI_BASE_URL}/static/favicon.png`}
 										class="size-24 rounded-full"
 										alt=""
 									/>
@@ -546,7 +546,7 @@
 						<img
 							id="logo"
 							crossorigin="anonymous"
-							src="{WEBUI_BASE_URL}/static/favicon.png"
+							src={$customLogo || `${WEBUI_BASE_URL}/static/favicon.png`}
 							class=" w-6 rounded-full"
 							alt=""
 						/>

--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -1,6 +1,6 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
-<ShortName>Open WebUI</ShortName>
-<Description>Search Open WebUI</Description>
+<ShortName>Hey! Carlton</ShortName>
+<Description>Search Hey! Carlton</Description>
 <InputEncoding>UTF-8</InputEncoding>
 <Image width="16" height="16" type="image/x-icon">http://localhost:5137/favicon.png</Image>
 <Url type="text/html" method="get" template="http://localhost:5137/?q={searchTerms}"/>


### PR DESCRIPTION
## Summary
- allow users to upload a custom PNG at startup and apply it as both primary and secondary logo
- replace visible "Open WebUI" branding with "Hey! Carlton" via constants and post-processing
- update layout and metadata to honor the custom logo and new name

## Testing
- `npm run lint:frontend` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run test:frontend` *(fails: vitest not found and dependency conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_68ae72e6122c832b920d1bd6002daf02