### PR TITLE
feat: allow uploading custom favicon

### DIFF
--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -1,11 +1,10 @@
-from fastapi import APIRouter, Depends, Request, HTTPException
+from fastapi import APIRouter, Depends, Request, HTTPException, UploadFile, File
 from pydantic import BaseModel, ConfigDict
 
 from typing import Optional
 
 from open_webui.utils.auth import get_admin_user, get_verified_user
-from open_webui.config import get_config, save_config
-from open_webui.config import BannerModel
+from open_webui.config import get_config, save_config, BannerModel, STATIC_DIR
 
 from open_webui.utils.tools import (
     get_tool_server_data,
@@ -328,3 +327,34 @@ async def get_banners(
     user=Depends(get_verified_user),
 ):
     return request.app.state.config.BANNERS
+
+
+############################
+# Favicon
+############################
+
+
+@router.post("/favicon")
+async def upload_favicon(
+    request: Request,
+    file: UploadFile = File(...),
+    user=Depends(get_admin_user),
+):
+    if not file.content_type or not file.content_type.startswith("image/"):
+        raise HTTPException(status_code=400, detail="Invalid image file")
+
+    contents = await file.read()
+
+    for path in [STATIC_DIR / "favicon.png", STATIC_DIR / "static" / "favicon.png"]:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "wb") as f:
+            f.write(contents)
+
+    if getattr(request.app.state.config, "WEBUI_URL", ""):
+        request.app.state.config.WEBUI_FAVICON_URL = (
+            f"{request.app.state.config.WEBUI_URL}/static/favicon.png"
+        )
+    else:
+        request.app.state.config.WEBUI_FAVICON_URL = "/static/favicon.png"
+
+    return {"status": "ok"}

--- a/src/lib/apis/configs/index.ts
+++ b/src/lib/apis/configs/index.ts
@@ -400,5 +400,35 @@ export const setBanners = async (token: string, banners: Banner[]) => {
 		throw error;
 	}
 
-	return res;
+        return res;
+};
+
+export const uploadFavicon = async (token: string, file: File) => {
+        let error = null;
+
+        const formData = new FormData();
+        formData.append('file', file);
+
+        const res = await fetch(`${WEBUI_API_BASE_URL}/configs/favicon`, {
+                method: 'POST',
+                headers: {
+                        Authorization: `Bearer ${token}`
+                },
+                body: formData
+        })
+                .then(async (res) => {
+                        if (!res.ok) throw await res.json();
+                        return res.json();
+                })
+                .catch((err) => {
+                        console.error(err);
+                        error = err.detail;
+                        return null;
+                });
+
+        if (error) {
+                throw error;
+        }
+
+        return res;
 };

--- a/src/lib/components/admin/Settings/Interface.svelte
+++ b/src/lib/components/admin/Settings/Interface.svelte
@@ -49,6 +49,14 @@
         let faviconFile: File | null = null;
         let faviconUrl = `${WEBUI_BASE_URL}/static/favicon.png`;
 
+        function handleFaviconChange(e: Event) {
+                const input = e.target as HTMLInputElement;
+                const files = input.files;
+                if (files && files.length) {
+                        faviconFile = files[0];
+                }
+        }
+
         const updateInterfaceHandler = async () => {
                 taskConfig = await updateTaskConfig(localStorage.token, taskConfig);
 
@@ -404,12 +412,7 @@
                                                         type="file"
                                                         accept="image/*"
                                                         class="text-xs"
-                                                        on:change={(e) => {
-                                                                const files = (e.target as HTMLInputElement).files;
-                                                                if (files && files.length) {
-                                                                        faviconFile = files[0];
-                                                                }
-                                                        }}
+                                                        on:change={handleFaviconChange}
                                                 />
                                         </div>
                                 </div>

--- a/src/lib/components/admin/Settings/Interface.svelte
+++ b/src/lib/components/admin/Settings/Interface.svelte
@@ -5,16 +5,16 @@
 	import { v4 as uuidv4 } from 'uuid';
 	import { toast } from 'svelte-sonner';
 
-	import { getBackendConfig, getModels, getTaskConfig, updateTaskConfig } from '$lib/apis';
-	import { setDefaultPromptSuggestions } from '$lib/apis/configs';
-	import { config, settings, user } from '$lib/stores';
-	import { createEventDispatcher, onMount, getContext } from 'svelte';
+        import { getBackendConfig, getModels, getTaskConfig, updateTaskConfig } from '$lib/apis';
+        import { setDefaultPromptSuggestions, getBanners, setBanners, uploadFavicon } from '$lib/apis/configs';
+        import { config, settings, user } from '$lib/stores';
+        import { createEventDispatcher, onMount, getContext } from 'svelte';
 
-	import { banners as _banners } from '$lib/stores';
-	import type { Banner } from '$lib/types';
+        import { banners as _banners } from '$lib/stores';
+        import type { Banner } from '$lib/types';
 
-	import { getBaseModels } from '$lib/apis/models';
-	import { getBanners, setBanners } from '$lib/apis/configs';
+        import { getBaseModels } from '$lib/apis/models';
+        import { WEBUI_BASE_URL } from '$lib/constants';
 
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import Switch from '$lib/components/common/Switch.svelte';
@@ -44,18 +44,26 @@
 		TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE: ''
 	};
 
-	let promptSuggestions = [];
-	let banners: Banner[] = [];
+        let promptSuggestions = [];
+        let banners: Banner[] = [];
+        let faviconFile: File | null = null;
+        let faviconUrl = `${WEBUI_BASE_URL}/static/favicon.png`;
 
-	const updateInterfaceHandler = async () => {
-		taskConfig = await updateTaskConfig(localStorage.token, taskConfig);
+        const updateInterfaceHandler = async () => {
+                taskConfig = await updateTaskConfig(localStorage.token, taskConfig);
 
-		promptSuggestions = promptSuggestions.filter((p) => p.content !== '');
-		promptSuggestions = await setDefaultPromptSuggestions(localStorage.token, promptSuggestions);
-		await updateBanners();
+                promptSuggestions = promptSuggestions.filter((p) => p.content !== '');
+                promptSuggestions = await setDefaultPromptSuggestions(localStorage.token, promptSuggestions);
+                await updateBanners();
 
-		await config.set(await getBackendConfig());
-	};
+                if (faviconFile) {
+                        await uploadFavicon(localStorage.token, faviconFile);
+                        faviconUrl = `${WEBUI_BASE_URL}/static/favicon.png?t=${Date.now()}`;
+                        faviconFile = null;
+                }
+
+                await config.set(await getBackendConfig());
+        };
 
 	const updateBanners = async () => {
 		_banners.set(await setBanners(localStorage.token, banners));
@@ -386,13 +394,31 @@
 			<div class="mb-3.5">
 				<div class=" mb-2.5 text-base font-medium">{$i18n.t('UI')}</div>
 
-				<hr class=" border-gray-100 dark:border-gray-850 my-2" />
+                                <hr class=" border-gray-100 dark:border-gray-850 my-2" />
 
-				<div class="mb-2.5">
-					<div class="flex w-full justify-between">
-						<div class=" self-center text-xs">
-							{$i18n.t('Banners')}
-						</div>
+                                <div class="mb-2.5">
+                                        <div class=" mb-1 text-xs font-medium">{$i18n.t('Favicon')}</div>
+                                        <div class="flex items-center space-x-2">
+                                                <img src={faviconUrl} alt="favicon" class="size-6 rounded" />
+                                                <input
+                                                        type="file"
+                                                        accept="image/*"
+                                                        class="text-xs"
+                                                        on:change={(e) => {
+                                                                const files = (e.target as HTMLInputElement).files;
+                                                                if (files && files.length) {
+                                                                        faviconFile = files[0];
+                                                                }
+                                                        }}
+                                                />
+                                        </div>
+                                </div>
+
+                                <div class="mb-2.5">
+                                        <div class="flex w-full justify-between">
+                                                <div class=" self-center text-xs">
+                                                        {$i18n.t('Banners')}
+                                                </div>
 
 						<button
 							class="p-1 px-3 text-xs flex rounded-sm transition"


### PR DESCRIPTION
## Summary
- add backend API to upload and replace favicon
- expose upload API and UI option in admin interface

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint config, svelte-kit, pylint not found)*
- `npm run test:frontend` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af617e4e68832bb7b4494d1831f4e8